### PR TITLE
Changed module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/hooklift/gowsdl
+module github.com/modfin/gowsdl


### PR DESCRIPTION
this is needed to be able to pull the gomodule from bitbucket.go/modfin/gowsdl